### PR TITLE
Avoid repainting an unchanging dock.

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -78,6 +78,11 @@ const MyDashActor = new Lang.Class({
         this.actor.connect('allocate', Lang.bind(this, this._allocate));
 
         this.actor._delegate = this;
+
+        // Since we are usually visible but not usually changing, make sure
+        // most repaint requests don't actually require us to repaint anything.
+        // This saves significant CPU when repainting the screen.
+        this.actor.set_offscreen_redirect(Clutter.OffscreenRedirect.ALWAYS);
     },
 
     _allocate: function(actor, box, flags) {


### PR DESCRIPTION
Since we are usually visible but not usually changing, make sure
most repaint requests don't actually require us to repaint anything.
This saves significant CPU when repainting the screen. In my case
gnome-shell's time spent under clutter_actor_paint dropped from
43% to 30% after this change. (LP: #1743976)